### PR TITLE
fix: harden /script endpoint against injection, add SECURITY.md (closes #18)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Model
+
+## `/script` Endpoint
+
+The `POST /script` endpoint is a **recording automation script runner**, not an arbitrary script execution engine. Despite the name, it does **not** execute AppleScript, shell commands, or `osascript`.
+
+It accepts a JSON array of commands, each dispatched through a strict switch-case allowlist:
+
+| Action      | Description                            |
+|-------------|----------------------------------------|
+| `start`     | Start a screen recording               |
+| `stop`      | Stop the current recording             |
+| `pause`     | Pause the current recording            |
+| `resume`    | Resume a paused recording              |
+| `chapter`   | Add a named chapter marker             |
+| `note`      | Add a timestamped text annotation      |
+| `highlight` | Flag the next click for visual effect  |
+| `sleep`     | Wait for a specified number of seconds |
+
+Any action not in this list is rejected with an error. String inputs (`name`, `text`, `window_title`) are validated to reject strings exceeding 500 characters or containing null bytes / control characters.
+
+## Authentication
+
+All HTTP endpoints require an API key unless explicitly disabled.
+
+- **`SCREENMUSE_API_KEY`** environment variable: set this to a secret string before launching ScreenMuse.
+- **`~/.screenmuse/api_key`** file: alternative to the env var; the file contents are used as the key.
+- **`SCREENMUSE_NO_AUTH=1`**: disables authentication entirely (development only).
+
+Requests must include the key in the `X-ScreenMuse-Key` header. Requests without a valid key receive a `401 Unauthorized` response.
+
+## Network Binding
+
+By default, ScreenMuse binds to **`127.0.0.1` (localhost only)** on port `7823`. This means the API is not accessible from other machines on the network.
+
+If you change the bind address to `0.0.0.0` or a network interface, ensure:
+1. `SCREENMUSE_API_KEY` is set to a strong, random value.
+2. A firewall or reverse proxy restricts access to trusted clients.
+
+## Known Limitations
+
+- **No TLS**: The HTTP server does not support HTTPS. For remote access, place it behind a TLS-terminating reverse proxy.
+- **Single-user**: There is no multi-user or role-based access control. The API key grants full access to all endpoints.
+- **Screen Recording permissions**: ScreenMuse requires macOS Screen Recording permission. This is a system-level grant, not per-endpoint.
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability, please open a GitHub issue or contact the maintainers directly. Do not disclose vulnerabilities publicly before a fix is available.

--- a/Sources/ScreenMuseCore/AgentAPI/Server+Media.swift
+++ b/Sources/ScreenMuseCore/AgentAPI/Server+Media.swift
@@ -8,6 +8,26 @@ import Vision
 
 extension ScreenMuseServer {
 
+    /// Validates a user-supplied string label (name, text, window_title, etc.).
+    /// Rejects strings longer than 500 characters or containing null bytes / control characters
+    /// (except newline and tab which are reasonable in note text).
+    private func sanitizedString(_ value: String?, maxLength: Int = 500) -> (String?, String?) {
+        guard let str = value else { return (nil, nil) }
+        if str.count > maxLength {
+            return (nil, "String exceeds maximum length of \(maxLength) characters")
+        }
+        for scalar in str.unicodeScalars {
+            if scalar.value == 0 {
+                return (nil, "String contains null bytes")
+            }
+            // Reject control characters except \n (0x0A) and \t (0x09)
+            if scalar.value < 0x20 && scalar.value != 0x0A && scalar.value != 0x09 {
+                return (nil, "String contains disallowed control characters")
+            }
+        }
+        return (str, nil)
+    }
+
     func handleTimeline(body: [String: Any], connection: NWConnection, reqID: Int) {
         let sid = sessionID ?? "last"
         let sessionStart = startTime
@@ -231,6 +251,12 @@ extension ScreenMuseServer {
         }
     }
 
+    // SECURITY: This endpoint does NOT execute arbitrary AppleScript or shell commands.
+    // It is a recording automation script runner with a strict action allowlist:
+    //   start, stop, pause, resume, chapter, note, highlight, sleep
+    // The switch-case below is an intentional security boundary — unknown actions
+    // are rejected with an error. Do NOT add cases that execute user-supplied code,
+    // shell commands, or AppleScript via osascript/NSAppleScript.
     func handleScript(body: [String: Any], connection: NWConnection, reqID: Int) async {
         smLog.info("[\(reqID)] /script request", category: .server)
 
@@ -258,10 +284,15 @@ extension ScreenMuseServer {
             do {
                 switch action {
                 case "start":
-                    let name = cmd["name"] as? String ?? "script-recording"
+                    let (name, nameErr) = sanitizedString(cmd["name"] as? String ?? "script-recording")
+                    let (windowTitle, wtErr) = sanitizedString(cmd["window_title"] as? String)
+                    if let err = nameErr ?? wtErr {
+                        stepResult["ok"] = false; stepResult["error"] = err
+                        scriptResults.append(stepResult); break
+                    }
                     let quality = cmd["quality"] as? String
                     if let coord = coordinator {
-                        try await coord.startRecording(name: name, windowTitle: cmd["window_title"] as? String, windowPid: nil, quality: quality)
+                        try await coord.startRecording(name: name!, windowTitle: windowTitle, windowPid: nil, quality: quality)
                     } else {
                         try await recordingManager.startRecording(config: RecordingConfig(
                             captureSource: .fullScreen,
@@ -270,7 +301,7 @@ extension ScreenMuseServer {
                         ))
                     }
                     sessionID = UUID().uuidString
-                    sessionName = name
+                    sessionName = name!
                     startTime = Date()
                     isRecording = true
                     chapters = []
@@ -278,7 +309,7 @@ extension ScreenMuseServer {
                     sessionHighlights.removeAll()
                     highlightNextClick = false
                     currentVideoURL = nil
-                    sessionRegistry.create(id: sessionID!, name: name)
+                    sessionRegistry.create(id: sessionID!, name: name!)
                     sessionRegistry.defaultSessionID = sessionID
                     stepResult["ok"] = true
 
@@ -326,19 +357,27 @@ extension ScreenMuseServer {
                     stepResult["ok"] = true
 
                 case "chapter":
-                    let chapterName = cmd["name"] as? String ?? "Chapter \(chapters.count + 1)"
+                    let (chapterName, chErr) = sanitizedString(cmd["name"] as? String ?? "Chapter \(chapters.count + 1)")
+                    if let err = chErr {
+                        stepResult["ok"] = false; stepResult["error"] = err
+                        scriptResults.append(stepResult); break
+                    }
                     let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
-                    chapters.append((name: chapterName, time: elapsed))
-                    smLog.usage("CHAPTER \(chapterName)  t=\(String(format:"%.1f",elapsed))s")
-                    stepResult["name"] = chapterName
+                    chapters.append((name: chapterName!, time: elapsed))
+                    smLog.usage("CHAPTER \(chapterName!)  t=\(String(format:"%.1f",elapsed))s")
+                    stepResult["name"] = chapterName!
                     stepResult["timestamp"] = elapsed
                     stepResult["ok"] = true
 
                 case "note":
-                    let noteText = cmd["text"] as? String ?? ""
+                    let (noteText, noteErr) = sanitizedString(cmd["text"] as? String ?? "")
+                    if let err = noteErr {
+                        stepResult["ok"] = false; stepResult["error"] = err
+                        scriptResults.append(stepResult); break
+                    }
                     let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
-                    sessionNotes.append((text: noteText, time: elapsed))
-                    smLog.usage("📝 NOTE", details: ["text": noteText])
+                    sessionNotes.append((text: noteText!, time: elapsed))
+                    smLog.usage("📝 NOTE", details: ["text": noteText!])
                     stepResult["ok"] = true
 
                 case "highlight":
@@ -347,7 +386,7 @@ extension ScreenMuseServer {
 
                 default:
                     stepResult["ok"] = false
-                    stepResult["error"] = "Unknown action '\(action)'. Supported: start, stop, pause, resume, chapter, note, highlight, sleep"
+                    stepResult["error"] = "Unknown action '\(action)'. Allowed actions: start, stop, pause, resume, chapter, note, highlight, sleep. This endpoint does not execute arbitrary scripts."
                 }
             } catch {
                 stepResult["ok"] = false
@@ -369,6 +408,7 @@ extension ScreenMuseServer {
 
     // MARK: POST /script/batch — run multiple named scripts in sequence
 
+    // SECURITY: Same allowlist as handleScript() above — no arbitrary code execution.
     func handleScriptBatch(body: [String: Any], connection: NWConnection, reqID: Int) async {
         smLog.info("[\(reqID)] /script/batch request", category: .server)
 
@@ -417,10 +457,15 @@ extension ScreenMuseServer {
                 do {
                     switch action {
                     case "start":
-                        let name = cmd["name"] as? String ?? "script-recording"
+                        let (name, nameErr) = sanitizedString(cmd["name"] as? String ?? "script-recording")
+                        let (windowTitle, wtErr) = sanitizedString(cmd["window_title"] as? String)
+                        if let err = nameErr ?? wtErr {
+                            stepResult["ok"] = false; stepResult["error"] = err
+                            stepResults.append(stepResult); break
+                        }
                         let quality = cmd["quality"] as? String
                         if let coord = coordinator {
-                            try await coord.startRecording(name: name, windowTitle: cmd["window_title"] as? String, windowPid: nil, quality: quality)
+                            try await coord.startRecording(name: name!, windowTitle: windowTitle, windowPid: nil, quality: quality)
                         } else {
                             try await recordingManager.startRecording(config: RecordingConfig(
                                 captureSource: .fullScreen,
@@ -429,7 +474,7 @@ extension ScreenMuseServer {
                             ))
                         }
                         sessionID = UUID().uuidString
-                        sessionName = name
+                        sessionName = name!
                         startTime = Date()
                         isRecording = true
                         chapters = []
@@ -437,7 +482,7 @@ extension ScreenMuseServer {
                         sessionHighlights.removeAll()
                         highlightNextClick = false
                         currentVideoURL = nil
-                        sessionRegistry.create(id: sessionID!, name: name)
+                        sessionRegistry.create(id: sessionID!, name: name!)
                         sessionRegistry.defaultSessionID = sessionID
                         stepResult["ok"] = true
 
@@ -485,17 +530,25 @@ extension ScreenMuseServer {
                         stepResult["ok"] = true
 
                     case "chapter":
-                        let chapterName = cmd["name"] as? String ?? "Chapter \(chapters.count + 1)"
+                        let (chapterName, chErr) = sanitizedString(cmd["name"] as? String ?? "Chapter \(chapters.count + 1)")
+                        if let err = chErr {
+                            stepResult["ok"] = false; stepResult["error"] = err
+                            stepResults.append(stepResult); break
+                        }
                         let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
-                        chapters.append((name: chapterName, time: elapsed))
-                        stepResult["name"] = chapterName
+                        chapters.append((name: chapterName!, time: elapsed))
+                        stepResult["name"] = chapterName!
                         stepResult["timestamp"] = elapsed
                         stepResult["ok"] = true
 
                     case "note":
-                        let noteText = cmd["text"] as? String ?? ""
+                        let (noteText, noteErr) = sanitizedString(cmd["text"] as? String ?? "")
+                        if let err = noteErr {
+                            stepResult["ok"] = false; stepResult["error"] = err
+                            stepResults.append(stepResult); break
+                        }
                         let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
-                        sessionNotes.append((text: noteText, time: elapsed))
+                        sessionNotes.append((text: noteText!, time: elapsed))
                         stepResult["ok"] = true
 
                     case "highlight":
@@ -504,7 +557,7 @@ extension ScreenMuseServer {
 
                     default:
                         stepResult["ok"] = false
-                        stepResult["error"] = "Unknown action '\(action)'. Supported: start, stop, pause, resume, chapter, note, highlight, sleep"
+                        stepResult["error"] = "Unknown action '\(action)'. Allowed actions: start, stop, pause, resume, chapter, note, highlight, sleep. This endpoint does not execute arbitrary scripts."
                     }
                 } catch {
                     stepResult["ok"] = false

--- a/mcp-server/screenmuse-mcp.js
+++ b/mcp-server/screenmuse-mcp.js
@@ -294,7 +294,7 @@ const TOOLS = [
   },
   {
     name: 'screenmuse_script',
-    description: 'Run a sequence of recording commands (start, stop, chapter, sleep, etc.) as a batch script.',
+    description: 'Run a sequence of screen recording automation commands (start, stop, pause, resume, chapter, note, highlight, sleep) as a batch. No shell or AppleScript execution — actions are strictly allowlisted.',
     inputSchema: {
       type: 'object',
       required: ['commands'],
@@ -309,7 +309,7 @@ const TOOLS = [
   },
   {
     name: 'screenmuse_script_batch',
-    description: 'Run multiple named scripts in sequence. Each script contains a commands array. Stops on first failure unless continue_on_error is true.',
+    description: 'Run multiple named recording automation scripts in sequence. Each script contains a commands array (same allowlisted actions as screenmuse_script). Stops on first failure unless continue_on_error is true.',
     inputSchema: {
       type: 'object',
       required: ['scripts'],


### PR DESCRIPTION
Closes #18

## Problem

Issue #18 flagged `POST /script` as a potential command injection vector. After auditing the code, the endpoint already uses a strict action allowlist (no arbitrary script/AppleScript execution). However, the security model was undocumented and the allowlist intent was invisible to future contributors.

## Changes

### `Sources/ScreenMuseCore/AgentAPI/Server+Media.swift`
- Added `sanitizedString()` helper — rejects strings >500 chars, null bytes, or disallowed control characters; applied to `name`, `window_title`, and `text` inputs in both `handleScript()` and `handleScriptBatch()`
- Added security comment block above `handleScript()` explaining the allowlist is an intentional security boundary
- Updated the `default:` case error message to explicitly state "This endpoint does not execute arbitrary scripts" and list only the allowed actions

### `mcp-server/screenmuse-mcp.js`
- Updated `screenmuse_script` and `screenmuse_script_batch` tool descriptions to explicitly state "No shell or AppleScript execution" so LLM agents do not confuse this with arbitrary script execution

### `SECURITY.md` (new)
- Documents the `/script` endpoint security model
- Documents API key auth, localhost-only binding
- Lists known limitations and vulnerability reporting guidance