### PR TITLE
fix: /script/batch double-append bug + OpenAPI response schemas

### DIFF
--- a/Sources/ScreenMuseCore/AgentAPI/OpenAPISpec.swift
+++ b/Sources/ScreenMuseCore/AgentAPI/OpenAPISpec.swift
@@ -181,7 +181,17 @@ enum OpenAPISpec {
                 "name":   { "type": "string" },
                 "text":   { "type": "string" }
               } } }
-            } } } } }
+            } } } } },
+            "responses": {
+              "200": { "description": "All steps completed successfully", "content": { "application/json": { "schema": { "type": "object", "properties": {
+                "ok":        { "type": "boolean" },
+                "steps_run": { "type": "integer" },
+                "steps":     { "type": "array", "items": { "type": "object" } },
+                "error":     { "type": "string", "nullable": true }
+              } } } } },
+              "400": { "description": "Invalid request (empty or missing commands array)" },
+              "500": { "description": "A step failed during execution" }
+            }
           }
         },
         "/upload/icloud": {
@@ -261,8 +271,16 @@ enum OpenAPISpec {
           "post": {
             "summary": "Validate a video file — check for real content vs black/empty recording",
             "requestBody": { "content": { "application/json": { "schema": {
+              "required": ["checks"],
               "properties": {
-                "source": { "type": "string", "description": "Video path or 'last'" }
+                "source": { "type": "string", "description": "Video path or 'last'", "default": "last" },
+                "checks": { "type": "array", "description": "Non-empty array of validation checks to run", "items": { "type": "object", "required": ["type"], "properties": {
+                  "type":     { "type": "string", "enum": ["duration", "frame_count", "no_black_frames", "text_at"], "description": "Check type" },
+                  "min":      { "type": "number", "description": "Minimum value (for duration, frame_count)" },
+                  "max":      { "type": "number", "description": "Maximum value (for duration)" },
+                  "time":     { "type": "number", "description": "Timestamp in seconds (for text_at)" },
+                  "expected": { "type": "string", "description": "Expected text to find (for text_at)" }
+                } } }
               }
             } } } }
           }
@@ -285,7 +303,16 @@ enum OpenAPISpec {
                 },
                 "continue_on_error": { "type": "boolean", "default": false }
               }
-            } } } }
+            } } } },
+            "responses": {
+              "200": { "description": "All scripts completed successfully", "content": { "application/json": { "schema": { "type": "object", "properties": {
+                "ok":          { "type": "boolean" },
+                "scripts_run": { "type": "integer" },
+                "scripts":     { "type": "array", "items": { "type": "object" } }
+              } } } } },
+              "400": { "description": "Invalid request (empty or missing scripts array)" },
+              "500": { "description": "One or more scripts failed during execution" }
+            }
           }
         },
         "/sessions": { "get": { "summary": "List all named recording sessions with metadata" } },

--- a/Sources/ScreenMuseCore/AgentAPI/Server+Media.swift
+++ b/Sources/ScreenMuseCore/AgentAPI/Server+Media.swift
@@ -281,6 +281,7 @@ extension ScreenMuseServer {
             }
 
             var stepResult: [String: Any] = ["step": idx + 1, "action": action]
+            var appended = false
             do {
                 switch action {
                 case "start":
@@ -288,7 +289,7 @@ extension ScreenMuseServer {
                     let (windowTitle, wtErr) = sanitizedString(cmd["window_title"] as? String)
                     if let err = nameErr ?? wtErr {
                         stepResult["ok"] = false; stepResult["error"] = err
-                        scriptResults.append(stepResult); break
+                        scriptResults.append(stepResult); appended = true; break
                     }
                     let quality = cmd["quality"] as? String
                     if let coord = coordinator {
@@ -360,7 +361,7 @@ extension ScreenMuseServer {
                     let (chapterName, chErr) = sanitizedString(cmd["name"] as? String ?? "Chapter \(chapters.count + 1)")
                     if let err = chErr {
                         stepResult["ok"] = false; stepResult["error"] = err
-                        scriptResults.append(stepResult); break
+                        scriptResults.append(stepResult); appended = true; break
                     }
                     let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
                     chapters.append((name: chapterName!, time: elapsed))
@@ -373,7 +374,7 @@ extension ScreenMuseServer {
                     let (noteText, noteErr) = sanitizedString(cmd["text"] as? String ?? "")
                     if let err = noteErr {
                         stepResult["ok"] = false; stepResult["error"] = err
-                        scriptResults.append(stepResult); break
+                        scriptResults.append(stepResult); appended = true; break
                     }
                     let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
                     sessionNotes.append((text: noteText!, time: elapsed))
@@ -395,7 +396,7 @@ extension ScreenMuseServer {
                 scriptResults.append(stepResult)
                 break
             }
-            scriptResults.append(stepResult)
+            if !appended { scriptResults.append(stepResult) }
         }
 
         sendResponse(connection: connection, status: scriptError == nil ? 200 : 500, body: [
@@ -454,6 +455,7 @@ extension ScreenMuseServer {
                 }
 
                 var stepResult: [String: Any] = ["step": idx + 1, "action": action]
+                var appended = false
                 do {
                     switch action {
                     case "start":
@@ -461,7 +463,7 @@ extension ScreenMuseServer {
                         let (windowTitle, wtErr) = sanitizedString(cmd["window_title"] as? String)
                         if let err = nameErr ?? wtErr {
                             stepResult["ok"] = false; stepResult["error"] = err
-                            stepResults.append(stepResult); break
+                            stepResults.append(stepResult); appended = true; break
                         }
                         let quality = cmd["quality"] as? String
                         if let coord = coordinator {
@@ -533,7 +535,7 @@ extension ScreenMuseServer {
                         let (chapterName, chErr) = sanitizedString(cmd["name"] as? String ?? "Chapter \(chapters.count + 1)")
                         if let err = chErr {
                             stepResult["ok"] = false; stepResult["error"] = err
-                            stepResults.append(stepResult); break
+                            stepResults.append(stepResult); appended = true; break
                         }
                         let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
                         chapters.append((name: chapterName!, time: elapsed))
@@ -545,7 +547,7 @@ extension ScreenMuseServer {
                         let (noteText, noteErr) = sanitizedString(cmd["text"] as? String ?? "")
                         if let err = noteErr {
                             stepResult["ok"] = false; stepResult["error"] = err
-                            stepResults.append(stepResult); break
+                            stepResults.append(stepResult); appended = true; break
                         }
                         let elapsed = startTime.map { Date().timeIntervalSince($0) } ?? 0
                         sessionNotes.append((text: noteText!, time: elapsed))
@@ -566,7 +568,7 @@ extension ScreenMuseServer {
                     stepResults.append(stepResult)
                     break
                 }
-                stepResults.append(stepResult)
+                if !appended { stepResults.append(stepResult) }
             }
 
             let scriptOK = scriptError == nil

--- a/Tests/ScreenMuseCoreTests/ScriptBatchTests.swift
+++ b/Tests/ScreenMuseCoreTests/ScriptBatchTests.swift
@@ -1,0 +1,320 @@
+#if canImport(XCTest)
+import XCTest
+@testable import ScreenMuseCore
+import Foundation
+
+/// Integration tests for /script and /script/batch endpoints (issue #21).
+///
+/// Starts a real NWListener on a dedicated test port (7826), sends actual HTTP
+/// requests via URLSession, and validates response shapes, status codes, and
+/// error handling — including the double-append bug fix for sanitization errors.
+///
+/// NOTES:
+///   • Actions that require Screen Recording permission (start, stop) are NOT
+///     exercised here because the permission is unavailable in CI. Instead,
+///     tests focus on input validation, error paths, and response structure.
+///   • Port 7826 avoids clashing with production (7823) or HTTPIntegrationTests (7825).
+final class ScriptBatchTests: XCTestCase {
+
+    static let testPort: UInt16 = 7826
+
+    // MARK: - setUp / tearDown
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await MainActor.run {
+            ScreenMuseServer.shared.apiKey = nil
+            try ScreenMuseServer.shared.start(port: ScriptBatchTests.testPort)
+        }
+        try await Task.sleep(nanoseconds: 400_000_000) // 400ms for NWListener
+    }
+
+    override func tearDown() async throws {
+        await MainActor.run {
+            ScreenMuseServer.shared.stop()
+        }
+        try await Task.sleep(nanoseconds: 200_000_000) // wait for port release
+        try await super.tearDown()
+    }
+
+    // MARK: - HTTP Helper
+
+    private func req(
+        _ method: String,
+        _ path: String,
+        json: Any
+    ) async throws -> (Int, [String: Any]) {
+        let url = URL(string: "http://127.0.0.1:\(ScriptBatchTests.testPort)\(path)")!
+        var request = URLRequest(url: url, timeoutInterval: 5)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: json)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        let body = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        return (statusCode, body)
+    }
+
+    // MARK: - /script tests
+
+    func testScriptEmptyCommandsReturns400() async throws {
+        let (status, json) = try await req("POST", "/script", json: ["commands": []])
+        XCTAssertEqual(status, 400, "Empty commands array must return 400")
+        XCTAssertNotNil(json["error"], "Error response must include 'error' field")
+    }
+
+    func testScriptMissingCommandsReturns400() async throws {
+        let (status, json) = try await req("POST", "/script", json: ["foo": "bar"])
+        XCTAssertEqual(status, 400, "Missing commands key must return 400")
+        XCTAssertNotNil(json["error"])
+    }
+
+    func testScriptHighlightReturnsOK() async throws {
+        // "highlight" doesn't require recording permission
+        let (status, json) = try await req("POST", "/script", json: [
+            "commands": [["action": "highlight"]]
+        ])
+        XCTAssertEqual(status, 200)
+        XCTAssertEqual(json["ok"] as? Bool, true)
+        XCTAssertEqual(json["steps_run"] as? Int, 1)
+        let steps = json["steps"] as? [[String: Any]] ?? []
+        XCTAssertEqual(steps.count, 1, "Must have exactly 1 step")
+        XCTAssertEqual(steps[0]["ok"] as? Bool, true)
+        XCTAssertEqual(steps[0]["action"] as? String, "highlight")
+    }
+
+    func testScriptMultipleHighlightsAndSleep() async throws {
+        let (status, json) = try await req("POST", "/script", json: [
+            "commands": [
+                ["action": "highlight"],
+                ["sleep": 0.01],
+                ["action": "highlight"]
+            ]
+        ])
+        XCTAssertEqual(status, 200)
+        XCTAssertEqual(json["ok"] as? Bool, true)
+        XCTAssertEqual(json["steps_run"] as? Int, 3)
+        let steps = json["steps"] as? [[String: Any]] ?? []
+        XCTAssertEqual(steps.count, 3)
+        // All steps should be ok
+        for step in steps {
+            XCTAssertEqual(step["ok"] as? Bool, true)
+        }
+    }
+
+    func testScriptUnknownActionReturnsError() async throws {
+        let (status, json) = try await req("POST", "/script", json: [
+            "commands": [["action": "execute_shell"]]
+        ])
+        // Unknown action doesn't throw, so script completes with 200 but step has ok=false
+        XCTAssertEqual(status, 200)
+        let steps = json["steps"] as? [[String: Any]] ?? []
+        XCTAssertEqual(steps.count, 1)
+        XCTAssertEqual(steps[0]["ok"] as? Bool, false)
+        XCTAssertNotNil(steps[0]["error"])
+        let errorStr = steps[0]["error"] as? String ?? ""
+        XCTAssertTrue(errorStr.contains("Unknown action"), "Error must mention unknown action")
+        XCTAssertTrue(errorStr.contains("does not execute arbitrary scripts"),
+                      "Error must include security note")
+    }
+
+    func testScriptSanitizationErrorDoesNotDuplicateStep() async throws {
+        // A name > 500 chars should trigger sanitization failure.
+        // Before the fix, this would appear TWICE in the steps array.
+        let longName = String(repeating: "A", count: 501)
+        let (status, json) = try await req("POST", "/script", json: [
+            "commands": [["action": "chapter", "name": longName]]
+        ])
+        // Script completes (no throw), so 200
+        XCTAssertEqual(status, 200)
+        let steps = json["steps"] as? [[String: Any]] ?? []
+        XCTAssertEqual(steps.count, 1,
+                       "Sanitization error must produce exactly 1 step entry, not 2 (double-append bug)")
+        XCTAssertEqual(steps[0]["ok"] as? Bool, false)
+        let errorStr = steps[0]["error"] as? String ?? ""
+        XCTAssertTrue(errorStr.contains("maximum length"),
+                      "Error should mention max length constraint")
+    }
+
+    func testScriptStartSanitizationErrorDoesNotDuplicate() async throws {
+        let longName = String(repeating: "X", count: 501)
+        let (status, json) = try await req("POST", "/script", json: [
+            "commands": [["action": "start", "name": longName]]
+        ])
+        XCTAssertEqual(status, 200)
+        let steps = json["steps"] as? [[String: Any]] ?? []
+        XCTAssertEqual(steps.count, 1,
+                       "Start action sanitization error must produce exactly 1 step (double-append fix)")
+        XCTAssertEqual(steps[0]["ok"] as? Bool, false)
+    }
+
+    func testScriptNoteSanitizationErrorDoesNotDuplicate() async throws {
+        let longText = String(repeating: "Z", count: 501)
+        let (status, json) = try await req("POST", "/script", json: [
+            "commands": [["action": "note", "text": longText]]
+        ])
+        XCTAssertEqual(status, 200)
+        let steps = json["steps"] as? [[String: Any]] ?? []
+        XCTAssertEqual(steps.count, 1,
+                       "Note action sanitization error must produce exactly 1 step (double-append fix)")
+        XCTAssertEqual(steps[0]["ok"] as? Bool, false)
+    }
+
+    func testScriptResponseIncludesErrorKeyAsNull() async throws {
+        // On success, "error" should be null/nil
+        let (status, json) = try await req("POST", "/script", json: [
+            "commands": [["action": "highlight"]]
+        ])
+        XCTAssertEqual(status, 200)
+        // The key "error" must exist in the response (even if null)
+        XCTAssertTrue(json.keys.contains("error"), "Response must include 'error' key even on success")
+    }
+
+    // MARK: - /script/batch tests
+
+    func testBatchEmptyScriptsReturns400() async throws {
+        let (status, json) = try await req("POST", "/script/batch", json: ["scripts": []])
+        XCTAssertEqual(status, 400, "Empty scripts array must return 400")
+        XCTAssertNotNil(json["error"])
+    }
+
+    func testBatchMissingScriptsKeyReturns400() async throws {
+        let (status, json) = try await req("POST", "/script/batch", json: ["foo": "bar"])
+        XCTAssertEqual(status, 400, "Missing scripts key must return 400")
+        XCTAssertNotNil(json["error"])
+    }
+
+    func testBatchHappyPathTwoScripts() async throws {
+        let (status, json) = try await req("POST", "/script/batch", json: [
+            "scripts": [
+                ["name": "setup", "commands": [["action": "highlight"]]],
+                ["name": "actions", "commands": [["action": "highlight"], ["sleep": 0.01]]]
+            ]
+        ])
+        XCTAssertEqual(status, 200)
+        XCTAssertEqual(json["ok"] as? Bool, true)
+        XCTAssertEqual(json["scripts_run"] as? Int, 2)
+        let scripts = json["scripts"] as? [[String: Any]] ?? []
+        XCTAssertEqual(scripts.count, 2)
+        XCTAssertEqual(scripts[0]["name"] as? String, "setup")
+        XCTAssertEqual(scripts[0]["ok"] as? Bool, true)
+        XCTAssertEqual(scripts[0]["steps_run"] as? Int, 1)
+        XCTAssertEqual(scripts[1]["name"] as? String, "actions")
+        XCTAssertEqual(scripts[1]["ok"] as? Bool, true)
+        XCTAssertEqual(scripts[1]["steps_run"] as? Int, 2)
+    }
+
+    func testBatchMissingCommandsInScriptReturnsError() async throws {
+        let (status, json) = try await req("POST", "/script/batch", json: [
+            "scripts": [
+                ["name": "broken"]  // no "commands" key
+            ]
+        ])
+        XCTAssertEqual(status, 500, "Batch with missing commands should return 500")
+        XCTAssertEqual(json["ok"] as? Bool, false)
+        let scripts = json["scripts"] as? [[String: Any]] ?? []
+        XCTAssertEqual(scripts.count, 1)
+        XCTAssertEqual(scripts[0]["ok"] as? Bool, false)
+        let errorStr = scripts[0]["error"] as? String ?? ""
+        XCTAssertTrue(errorStr.contains("missing or empty"), "Error should mention missing commands")
+    }
+
+    func testBatchEmptyCommandsInScriptReturnsError() async throws {
+        let (status, json) = try await req("POST", "/script/batch", json: [
+            "scripts": [
+                ["name": "empty-cmds", "commands": []]
+            ]
+        ])
+        XCTAssertEqual(status, 500)
+        XCTAssertEqual(json["ok"] as? Bool, false)
+        let scripts = json["scripts"] as? [[String: Any]] ?? []
+        XCTAssertEqual(scripts[0]["ok"] as? Bool, false)
+    }
+
+    func testBatchContinueOnErrorFalseStopsOnFirstFailure() async throws {
+        // Default continue_on_error is false.
+        // First script has missing commands → fails. Second script should NOT run.
+        let (status, json) = try await req("POST", "/script/batch", json: [
+            "scripts": [
+                ["name": "broken"],  // no commands → fails
+                ["name": "should-not-run", "commands": [["action": "highlight"]]]
+            ]
+        ])
+        XCTAssertEqual(status, 500)
+        XCTAssertEqual(json["ok"] as? Bool, false)
+        XCTAssertEqual(json["scripts_run"] as? Int, 1,
+                       "With continue_on_error=false, must stop after first failure")
+        let scripts = json["scripts"] as? [[String: Any]] ?? []
+        XCTAssertEqual(scripts.count, 1, "Only the failed script should appear in results")
+    }
+
+    func testBatchContinueOnErrorTrueContinuesPastFailures() async throws {
+        let (status, json) = try await req("POST", "/script/batch", json: [
+            "continue_on_error": true,
+            "scripts": [
+                ["name": "broken"],  // no commands → fails
+                ["name": "should-run", "commands": [["action": "highlight"]]]
+            ]
+        ])
+        XCTAssertEqual(status, 500, "Batch with any failure returns 500")
+        XCTAssertEqual(json["ok"] as? Bool, false)
+        XCTAssertEqual(json["scripts_run"] as? Int, 2,
+                       "With continue_on_error=true, must run all scripts")
+        let scripts = json["scripts"] as? [[String: Any]] ?? []
+        XCTAssertEqual(scripts.count, 2)
+        XCTAssertEqual(scripts[0]["ok"] as? Bool, false, "First script must fail")
+        XCTAssertEqual(scripts[1]["ok"] as? Bool, true, "Second script must succeed")
+    }
+
+    func testBatchSanitizationErrorDoesNotDuplicateStep() async throws {
+        let longName = String(repeating: "B", count: 501)
+        let (status, json) = try await req("POST", "/script/batch", json: [
+            "scripts": [
+                ["name": "sanitize-test", "commands": [["action": "chapter", "name": longName]]]
+            ]
+        ])
+        // The script completes (chapter fails but no throw), so the script itself is ok=true
+        // but the step has ok=false
+        XCTAssertEqual(status, 200)
+        let scripts = json["scripts"] as? [[String: Any]] ?? []
+        XCTAssertEqual(scripts.count, 1)
+        let steps = scripts[0]["steps"] as? [[String: Any]] ?? []
+        XCTAssertEqual(steps.count, 1,
+                       "Batch: sanitization error must produce exactly 1 step, not 2 (double-append fix)")
+        XCTAssertEqual(steps[0]["ok"] as? Bool, false)
+    }
+
+    func testBatchScriptNameDefaultsWhenOmitted() async throws {
+        let (status, json) = try await req("POST", "/script/batch", json: [
+            "scripts": [
+                ["commands": [["action": "highlight"]]]  // no "name" key
+            ]
+        ])
+        XCTAssertEqual(status, 200)
+        let scripts = json["scripts"] as? [[String: Any]] ?? []
+        XCTAssertEqual(scripts.count, 1)
+        let name = scripts[0]["name"] as? String ?? ""
+        XCTAssertEqual(name, "script_1", "Omitted name should default to 'script_<index>'")
+    }
+
+    func testBatchResponseShape() async throws {
+        let (status, json) = try await req("POST", "/script/batch", json: [
+            "scripts": [
+                ["name": "s1", "commands": [["action": "highlight"]]]
+            ]
+        ])
+        XCTAssertEqual(status, 200)
+        // Verify top-level keys
+        XCTAssertNotNil(json["ok"], "Response must include 'ok'")
+        XCTAssertNotNil(json["scripts_run"], "Response must include 'scripts_run'")
+        XCTAssertNotNil(json["scripts"], "Response must include 'scripts'")
+        // Verify per-script keys
+        let scripts = json["scripts"] as? [[String: Any]] ?? []
+        let script = scripts[0]
+        XCTAssertNotNil(script["name"], "Script result must include 'name'")
+        XCTAssertNotNil(script["ok"], "Script result must include 'ok'")
+        XCTAssertNotNil(script["steps_run"], "Script result must include 'steps_run'")
+        XCTAssertNotNil(script["steps"], "Script result must include 'steps'")
+    }
+}
+#endif


### PR DESCRIPTION
Backlog item #4. The /script/batch endpoint was documented in AGENT_API.md and the README but had a double-append bug. This fixes it and adds the missing OpenAPI response schemas so the endpoint matches its documentation.