### PR TITLE
fix: add workflow scripts + generalize agent doc paths

### DIFF
--- a/docs/agent-integration/AGENT-INTEGRATION.md
+++ b/docs/agent-integration/AGENT-INTEGRATION.md
@@ -439,10 +439,10 @@ await browser.close();
 
 **Video files saved to:**
 ```
-/Users/Vera/Movies/ScreenMuse/
+~/Movies/ScreenMuse/
   google-search-stripe-api_2026-03-28_18-30-45.mp4
   
-/Users/Vera/Movies/ScreenMuse/Exports/
+~/Movies/ScreenMuse/Exports/
   google-search-stripe-api_2026-03-28_18-30-45.gif
 ```
 
@@ -498,7 +498,7 @@ await preflight();
 await produceVideo(plan);
 
 // 4. Validate + report
-"✅ Video complete: /Users/Vera/Movies/ScreenMuse/...
+"✅ Video complete: ~/Movies/ScreenMuse/...
 Size: 1.8 MB, Duration: 20.3s, Quality: ✅ (0.089 MB/s)"
 ```
 

--- a/docs/agent-integration/FOR-DEVELOPERS.md
+++ b/docs/agent-integration/FOR-DEVELOPERS.md
@@ -239,7 +239,7 @@ $ curl http://localhost:7823/status
 **For debugging:**
 ```bash
 # Where should we look for logs?
-/Users/Vera/Library/Logs/ScreenMuse/app.log ?
+~/Library/Logs/ScreenMuse/app.log
 
 # What indicates HTTP server started successfully?
 # Add startup log: "HTTP server listening on :7823"
@@ -338,7 +338,7 @@ $ curl http://localhost:7823/status
 ### 1. Basic Smoke Test
 
 ```bash
-cd /Users/Vera/.openclaw/workspace/skills/screenmuse-video-production
+cd docs/agent-integration
 
 # Test pre-flight check
 node scripts/produce-video.js
@@ -350,8 +350,8 @@ node scripts/produce-video.js \
   --query="stripe api documentation"
 
 # Expected output:
-# ✅ Video: /Users/Vera/Movies/ScreenMuse/google-search-stripe-api-....mp4
-# ✅ GIF: /Users/Vera/Movies/ScreenMuse/Exports/google-search-stripe-api-....gif
+# ✅ Video: ~/Movies/ScreenMuse/google-search-stripe-api-....mp4
+# ✅ GIF: ~/Movies/ScreenMuse/Exports/google-search-stripe-api-....gif
 # ✅ Quality: HAS CONTENT (> 0.05 MB/s)
 ```
 
@@ -601,7 +601,7 @@ skills/screenmuse-video-production/
 8. Implement frame drop detection
 9. Add batch export formats
 
-### For Us (OpenClaw/Vera)
+### For OpenClaw Agents
 
 **Once API is reliable:**
 1. Build remaining 3 workflows (form-fill, product-hunt, landing-page)

--- a/docs/agent-integration/GETTING-STARTED.md
+++ b/docs/agent-integration/GETTING-STARTED.md
@@ -53,7 +53,7 @@ npx playwright install chromium
 ### 2. Test Basic Recording
 
 ```bash
-cd /Users/Vera/.openclaw/workspace/skills/screenmuse-video-production
+cd <your-skill-directory>
 
 node scripts/produce-video.js \
   --workflow=google-search \
@@ -62,8 +62,8 @@ node scripts/produce-video.js \
 
 **Expected output:**
 ```
-✅ Video: /Users/Vera/Movies/ScreenMuse/google-search-....mp4
-✅ GIF: /Users/Vera/Movies/ScreenMuse/Exports/google-search-....gif
+✅ Video: ~/Movies/ScreenMuse/google-search-<timestamp>.mp4
+✅ GIF: ~/Movies/ScreenMuse/Exports/google-search-<timestamp>.gif
 ✅ Quality: HAS CONTENT (0.089 MB/s)
 ```
 
@@ -369,6 +369,6 @@ console.log(windows.data);
 ---
 
 **Official repo:** https://github.com/hnshah/screenmuse  
-**Our system:** `/Users/Vera/.openclaw/workspace/skills/screenmuse-video-production/`
+**Our system:** `docs/agent-integration/`
 
 **Ready to create production-quality demo videos in 3 minutes.** 🎬

--- a/docs/agent-integration/scripts/package.json
+++ b/docs/agent-integration/scripts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "screenmuse-agent-scripts",
+  "version": "1.0.0",
+  "description": "Autonomous video production scripts for AI agents using ScreenMuse",
+  "main": "produce-video.js",
+  "scripts": {
+    "record": "node produce-video.js",
+    "google-search": "node produce-video.js --workflow=google-search",
+    "docs": "node produce-video.js --workflow=docs-navigation"
+  },
+  "dependencies": {
+    "playwright": "^1.40.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/docs/agent-integration/scripts/produce-video.js
+++ b/docs/agent-integration/scripts/produce-video.js
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/**
+ * produce-video.js — Autonomous video production runner for AI agents
+ *
+ * Orchestrates the full recording pipeline:
+ *   pre-flight checks → browser launch → window positioning →
+ *   ScreenMuse start → workflow execution → stop → quality validation → GIF export
+ *
+ * Prerequisites:
+ *   npm install playwright
+ *   npx playwright install chromium
+ *   ScreenMuse running: curl http://localhost:7823/status
+ *
+ * Usage:
+ *   node scripts/produce-video.js --workflow=google-search --query="stripe api docs"
+ *   node scripts/produce-video.js --workflow=docs-navigation --url="https://nextjs.org/docs"
+ *   node scripts/produce-video.js --custom=./my-workflow.js
+ *   node scripts/produce-video.js --workflow=google-search --quality=high --duration=30
+ */
+
+const { chromium } = require('playwright');
+const path = require('path');
+const fs = require('fs');
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+const SCREENMUSE_URL = process.env.SCREENMUSE_URL || 'http://localhost:7823';
+const QUALITY_THRESHOLD_MB_PER_S = parseFloat(process.env.QUALITY_THRESHOLD || '0.05');
+const WINDOW_WIDTH = parseInt(process.env.WINDOW_WIDTH || '1440');
+const WINDOW_HEIGHT = parseInt(process.env.WINDOW_HEIGHT || '900');
+
+// Parse CLI args
+const args = parseArgs(process.argv.slice(2));
+
+// ── ScreenMuse Client ─────────────────────────────────────────────────────────
+
+class ScreenMuse {
+  constructor(baseURL = SCREENMUSE_URL) {
+    this.baseURL = baseURL;
+    this.apiKey = process.env.SCREENMUSE_API_KEY || readAPIKey();
+  }
+
+  async request(method, endpoint, body) {
+    const headers = { 'Content-Type': 'application/json' };
+    if (this.apiKey) headers['X-ScreenMuse-Key'] = this.apiKey;
+
+    const res = await fetch(`${this.baseURL}${endpoint}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new Error(`ScreenMuse ${method} ${endpoint} → ${res.status}: ${json.error || JSON.stringify(json)}`);
+    }
+    return json;
+  }
+
+  async status() { return this.request('GET', '/status'); }
+  async health() { return this.request('GET', '/health'); }
+
+  async start(options = {}) {
+    return this.request('POST', '/start', options);
+  }
+
+  async stop() { return this.request('POST', '/stop'); }
+  async chapter(name) { return this.request('POST', '/chapter', { name }); }
+  async highlight() { return this.request('POST', '/highlight'); }
+  async note(text) { return this.request('POST', '/note', { text }); }
+
+  async export(videoPath, format = 'gif') {
+    return this.request('POST', '/export', { path: videoPath, format, async: true });
+  }
+
+  async pollJob(jobId, timeoutMs = 60000) {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const job = await this.request('GET', `/job/${jobId}`);
+      if (job.status === 'completed') return job.result;
+      if (job.status === 'failed') throw new Error(`Job ${jobId} failed: ${job.error}`);
+      await sleep(1000);
+    }
+    throw new Error(`Job ${jobId} timed out after ${timeoutMs}ms`);
+  }
+
+  async windows() { return this.request('GET', '/windows'); }
+
+  async focusWindow(app) {
+    return this.request('POST', '/window/focus', { app });
+  }
+
+  async positionWindow(app, frame) {
+    return this.request('POST', '/window/position', { app, ...frame });
+  }
+}
+
+// ── Pre-flight Checks ─────────────────────────────────────────────────────────
+
+async function preflight(sm) {
+  console.log('🔍 Pre-flight checks...');
+
+  // 1. ScreenMuse responding
+  let health;
+  try {
+    health = await sm.health();
+  } catch (e) {
+    throw new Error(
+      `ScreenMuse not responding at ${SCREENMUSE_URL}\n` +
+      'Fix: Ensure ScreenMuse.app is running and HTTP server is started.\n' +
+      'Check: curl http://localhost:7823/status'
+    );
+  }
+
+  // 2. Screen recording permission
+  if (health.permissions?.screen_recording === false) {
+    throw new Error(
+      'Screen recording permission not granted.\n' +
+      'Fix: System Settings → Privacy & Security → Screen Recording → ScreenMuse ✓\n' +
+      'Then relaunch ScreenMuse.'
+    );
+  }
+
+  // 3. Not already recording
+  const status = await sm.status();
+  if (status.recording) {
+    throw new Error(
+      'ScreenMuse is already recording. Stop the current recording first:\n' +
+      'curl -X POST http://localhost:7823/stop'
+    );
+  }
+
+  console.log(`✅ ScreenMuse ${health.version || 'ready'} — pre-flight passed`);
+  return health;
+}
+
+// ── Quality Validation ────────────────────────────────────────────────────────
+
+function validateQuality(result) {
+  const { path: videoPath, duration, size_mb } = result;
+
+  if (!videoPath || !fs.existsSync(videoPath)) {
+    throw new Error(`Video file not found: ${videoPath}`);
+  }
+
+  const stats = fs.statSync(videoPath);
+  if (stats.size === 0) {
+    throw new Error('Video file is empty — recording may have failed silently');
+  }
+
+  if (duration && size_mb) {
+    const mbPerSecond = size_mb / duration;
+    if (mbPerSecond < QUALITY_THRESHOLD_MB_PER_S) {
+      throw new Error(
+        `Quality check failed: ${mbPerSecond.toFixed(3)} MB/s is below threshold ${QUALITY_THRESHOLD_MB_PER_S} MB/s\n` +
+        'The video likely contains no content. Check screen recording permissions.'
+      );
+    }
+    console.log(`✅ Quality: ${mbPerSecond.toFixed(3)} MB/s (${size_mb.toFixed(1)} MB, ${duration.toFixed(1)}s)`);
+  }
+
+  return videoPath;
+}
+
+// ── GIF Export ────────────────────────────────────────────────────────────────
+
+async function exportGIF(sm, videoPath) {
+  console.log('🎬 Exporting GIF...');
+  try {
+    const job = await sm.export(videoPath, 'gif');
+    if (job.job_id) {
+      const result = await sm.pollJob(job.job_id);
+      console.log(`✅ GIF: ${result.path}`);
+      return result.path;
+    }
+    if (job.path) {
+      console.log(`✅ GIF: ${job.path}`);
+      return job.path;
+    }
+  } catch (e) {
+    console.warn(`⚠️  GIF export failed (non-fatal): ${e.message}`);
+  }
+  return null;
+}
+
+// ── Main Runner ───────────────────────────────────────────────────────────────
+
+async function main() {
+  const sm = new ScreenMuse();
+
+  // Pre-flight
+  await preflight(sm);
+
+  // Load workflow
+  const workflow = await loadWorkflow(args);
+
+  // Launch browser
+  console.log(`🌐 Launching browser (${WINDOW_WIDTH}×${WINDOW_HEIGHT})...`);
+  const browser = await chromium.launch({
+    headless: false,
+    args: [
+      `--window-size=${WINDOW_WIDTH},${WINDOW_HEIGHT}`,
+      '--window-position=0,0',
+      '--no-default-browser-check',
+      '--disable-extensions',
+    ],
+  });
+
+  const context = await browser.newContext({
+    viewport: { width: WINDOW_WIDTH, height: WINDOW_HEIGHT - 70 },
+  });
+  const page = await context.newPage();
+
+  let videoResult = null;
+  let gifPath = null;
+
+  try {
+    // Position window
+    await sleep(500); // let browser fully open
+    try {
+      await sm.positionWindow('Chromium', {
+        x: 0, y: 0,
+        width: WINDOW_WIDTH,
+        height: WINDOW_HEIGHT,
+      });
+    } catch {
+      // Non-fatal — window positioning may fail if window isn't detected yet
+    }
+
+    // Start recording
+    const recordingName = args.name || `${workflow.name}-${Date.now()}`;
+    console.log(`📹 Starting recording: ${recordingName}`);
+    await sm.start({
+      name: recordingName,
+      window: 'Chromium',
+      quality: args.quality || 'high',
+    });
+
+    // Run workflow
+    console.log(`▶️  Running workflow: ${workflow.name}`);
+    await workflow.run(page, sm, args);
+
+    // Stop recording
+    console.log('⏹️  Stopping recording...');
+    videoResult = await sm.stop();
+
+    // Validate quality
+    const videoPath = validateQuality(videoResult);
+    console.log(`✅ Video: ${videoPath}`);
+
+    // Export GIF
+    gifPath = await exportGIF(sm, videoPath);
+
+    return { video: videoPath, gif: gifPath, metadata: videoResult };
+  } finally {
+    await browser.close();
+  }
+}
+
+// ── Workflow Loader ───────────────────────────────────────────────────────────
+
+async function loadWorkflow(args) {
+  if (args.custom) {
+    const customPath = path.resolve(args.custom);
+    if (!fs.existsSync(customPath)) {
+      throw new Error(`Custom workflow not found: ${customPath}`);
+    }
+    return require(customPath);
+  }
+
+  const workflowName = args.workflow || 'google-search';
+  const builtins = {
+    'google-search': () => require('../workflows/google-search.js'),
+    'docs-navigation': () => require('../workflows/docs-navigation.js'),
+    'product-demo': () => require('../workflows/product-demo.js'),
+  };
+
+  if (!builtins[workflowName]) {
+    const available = Object.keys(builtins).join(', ');
+    throw new Error(`Unknown workflow: ${workflowName}\nAvailable: ${available}\nOr use --custom=./my-workflow.js`);
+  }
+
+  return builtins[workflowName]();
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function parseArgs(argv) {
+  const result = {};
+  for (const arg of argv) {
+    const [key, ...rest] = arg.replace(/^--/, '').split('=');
+    result[key] = rest.join('=') || true;
+  }
+  return result;
+}
+
+function readAPIKey() {
+  try {
+    const keyPath = path.join(process.env.HOME || '~', '.screenmuse', 'api_key');
+    if (fs.existsSync(keyPath)) {
+      return fs.readFileSync(keyPath, 'utf8').trim();
+    }
+  } catch {
+    // No key file — authentication may be disabled
+  }
+  return null;
+}
+
+// ── Entry Point ───────────────────────────────────────────────────────────────
+
+main()
+  .then(result => {
+    console.log('\n✅ Production complete!');
+    console.log(`   Video: ${result.video}`);
+    if (result.gif) console.log(`   GIF:   ${result.gif}`);
+    process.exit(0);
+  })
+  .catch(err => {
+    console.error('\n❌ Production failed:', err.message);
+    process.exit(1);
+  });

--- a/docs/agent-integration/workflows/docs-navigation.js
+++ b/docs/agent-integration/workflows/docs-navigation.js
@@ -1,0 +1,67 @@
+/**
+ * docs-navigation.js — Documentation site navigation workflow
+ *
+ * Records natural browsing of a documentation site:
+ *   Load home → open sidebar → expand section → read article → scroll
+ *
+ * Args:
+ *   --url="https://nextjs.org/docs"  (default)
+ *
+ * Duration: ~25 seconds
+ */
+
+const name = 'docs-navigation';
+
+async function run(page, sm, args) {
+  const url = args.url || 'https://nextjs.org/docs';
+
+  // Load docs homepage
+  await sm.chapter('Open documentation');
+  await page.goto(url, { waitUntil: 'networkidle' });
+  await sleep(2000);
+
+  // Scroll down to show content
+  await sm.chapter('Browse docs');
+  await page.mouse.wheel(0, 200);
+  await sleep(1000);
+
+  // Find and hover a sidebar link
+  const sidebarLink = page
+    .locator('nav a, aside a, [role="navigation"] a')
+    .filter({ hasText: /getting started|introduction|quick start|overview/i })
+    .first();
+
+  if (await sidebarLink.isVisible({ timeout: 3000 })) {
+    await sidebarLink.hover();
+    await sleep(800);
+    await sm.highlight();
+    await sidebarLink.click();
+    await page.waitForLoadState('domcontentloaded');
+    await sleep(2000);
+  }
+
+  // Scroll through the article
+  await sm.chapter('Read article');
+  for (let i = 0; i < 3; i++) {
+    await page.mouse.wheel(0, 400);
+    await sleep(800);
+  }
+
+  // Find a code block and hover it
+  const codeBlock = page.locator('pre code, .code-block').first();
+  if (await codeBlock.isVisible({ timeout: 2000 })) {
+    await codeBlock.scrollIntoViewIfNeeded();
+    await codeBlock.hover();
+    await sleep(1500);
+  }
+
+  // Scroll back to top
+  await page.keyboard.press('Home');
+  await sleep(1000);
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = { name, run };

--- a/docs/agent-integration/workflows/google-search.js
+++ b/docs/agent-integration/workflows/google-search.js
@@ -1,0 +1,75 @@
+/**
+ * google-search.js — Google search workflow
+ *
+ * Records a natural-looking Google search:
+ *   Open Google → type query slowly → submit → hover first result → click
+ *
+ * Args:
+ *   --query="stripe api documentation"  (default: "screenmuse github")
+ *
+ * Duration: ~20 seconds
+ */
+
+const name = 'google-search';
+
+async function run(page, sm, args) {
+  const query = args.query || 'screenmuse github';
+
+  // Navigate to Google
+  await sm.chapter('Open Google');
+  await page.goto('https://www.google.com', { waitUntil: 'networkidle' });
+  await sleep(1500);
+
+  // Dismiss cookie consent if present
+  try {
+    const acceptBtn = page.locator('button:has-text("Accept all"), button:has-text("I agree")').first();
+    if (await acceptBtn.isVisible({ timeout: 2000 })) {
+      await acceptBtn.click();
+      await sleep(500);
+    }
+  } catch {
+    // No consent dialog
+  }
+
+  // Click search box
+  await sm.chapter('Type search query');
+  const searchBox = page.locator('textarea[name="q"], input[name="q"]').first();
+  await searchBox.click();
+  await sleep(500);
+
+  // Type with human-like delays (50-150ms per character)
+  for (const char of query) {
+    await page.keyboard.type(char, { delay: 80 + Math.floor(Math.random() * 70) });
+  }
+  await sleep(800);
+
+  // Submit
+  await sm.chapter('View search results');
+  await sm.highlight(); // zoom effect on submit
+  await page.keyboard.press('Enter');
+  await page.waitForLoadState('networkidle');
+  await sleep(2000);
+
+  // Hover first organic result
+  const firstResult = page.locator('h3').first();
+  await firstResult.scrollIntoViewIfNeeded();
+  await firstResult.hover();
+  await sleep(1500);
+
+  // Click it
+  await sm.chapter('Open first result');
+  await sm.highlight();
+  await firstResult.click();
+  await page.waitForLoadState('domcontentloaded');
+  await sleep(2000);
+
+  // Scroll down a bit
+  await page.mouse.wheel(0, 300);
+  await sleep(1500);
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = { name, run };

--- a/docs/agent-integration/workflows/product-demo.js
+++ b/docs/agent-integration/workflows/product-demo.js
@@ -1,0 +1,74 @@
+/**
+ * product-demo.js — Generic product demo workflow
+ *
+ * Records a polished product walkthrough:
+ *   Land on page → scroll hero → click CTA → explore features → scroll to pricing
+ *
+ * Args:
+ *   --url="https://your-product.com"  (required)
+ *
+ * Duration: ~30 seconds
+ */
+
+const name = 'product-demo';
+
+async function run(page, sm, args) {
+  if (!args.url) {
+    throw new Error('product-demo requires --url="https://your-product.com"');
+  }
+
+  // Land on product page
+  await sm.chapter('Product homepage');
+  await page.goto(args.url, { waitUntil: 'networkidle' });
+  await sleep(2000);
+
+  // Slow scroll through hero
+  await sm.chapter('Hero section');
+  await page.mouse.wheel(0, 150);
+  await sleep(700);
+  await page.mouse.wheel(0, 150);
+  await sleep(1000);
+
+  // Find and hover primary CTA
+  const cta = page
+    .locator('a, button')
+    .filter({ hasText: /get started|sign up|try free|start free|demo|learn more/i })
+    .first();
+
+  if (await cta.isVisible({ timeout: 3000 })) {
+    await sm.chapter('Call to action');
+    await cta.scrollIntoViewIfNeeded();
+    await cta.hover();
+    await sleep(1500);
+  }
+
+  // Scroll through features
+  await sm.chapter('Features');
+  for (let i = 0; i < 4; i++) {
+    await page.mouse.wheel(0, 350);
+    await sleep(700 + Math.floor(Math.random() * 400));
+  }
+
+  // Find pricing section
+  await sm.chapter('Pricing');
+  const pricingSection = page
+    .locator('section, div')
+    .filter({ hasText: /pricing|plans|choose a plan/i })
+    .first();
+
+  if (await pricingSection.isVisible({ timeout: 2000 })) {
+    await pricingSection.scrollIntoViewIfNeeded();
+    await sleep(1500);
+    await sm.highlight();
+  }
+
+  // Final scroll to footer
+  await page.mouse.wheel(0, 300);
+  await sleep(1000);
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = { name, run };


### PR DESCRIPTION
Closes the two follow-up items flagged in PR #35 review by Oatis:

**1. Generalize hardcoded paths** — All `/Users/Vera/...` paths in `GETTING-STARTED.md`, `FOR-DEVELOPERS.md`, and `AGENT-INTEGRATION.md` replaced with `~/` or repo-relative paths. Any developer can now follow the docs without editing.

**2. Add the referenced scripts** — The docs described workflow scripts that did not exist. This PR adds them:

- `docs/agent-integration/scripts/produce-video.js` — Full autonomous recording runner: pre-flight health checks, Playwright browser launch, window positioning, ScreenMuse start/stop, quality validation (MB/s threshold), async GIF export with job polling, error handling with actionable messages.
- `docs/agent-integration/workflows/google-search.js` — Google search with human-like typing delays, chapter markers, highlight effects (~20s)
- `docs/agent-integration/workflows/docs-navigation.js` — Documentation site browsing with sidebar nav (~25s)
- `docs/agent-integration/workflows/product-demo.js` — Generic product landing page walkthrough: hero, CTA hover, features, pricing (~30s)
- `docs/agent-integration/scripts/package.json` — `npm install` entry point

**Usage after merge:**
```bash
cd docs/agent-integration && npm install
node scripts/produce-video.js --workflow=google-search --query="stripe api docs"
```